### PR TITLE
Fix bugs from PR #2 user-service integration

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,10 @@
 import { Routes, Route } from "react-router-dom";
-// import { useEffect } from "react";
 import Login from "./pages/Login/Login";
 import Signup from "./pages/Signup/Signup";
 import ChatPage from "./pages/Chat/ChatPage";
 import Home from "./pages/Home/Home";
 import Dashboard from "./pages/Dashboard/Dashboard";
-// import { validateToken } from "./api/auth";
+import VerifyEmail from "./pages/VerifyEmail/VerifyEmail";
 
 function App() {
   return (
@@ -14,6 +13,7 @@ function App() {
         <Route index="true" element={<Home />} />
         <Route path="login" element={<Login />} />
         <Route path="signup" element={<Signup />} />
+        <Route path="verify-email" element={<VerifyEmail />} />
         <Route path="chat" element={<ChatPage />} />
         <Route path="dashboard" element={<Dashboard />} />
       </Route>

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import ChatPage from "./pages/Chat/ChatPage";
 import Home from "./pages/Home/Home";
 import Dashboard from "./pages/Dashboard/Dashboard";
 import VerifyEmail from "./pages/VerifyEmail/VerifyEmail";
+import PrivateRoute from "./components/PrivateRoute";
 
 function App() {
   return (
@@ -14,8 +15,8 @@ function App() {
         <Route path="login" element={<Login />} />
         <Route path="signup" element={<Signup />} />
         <Route path="verify-email" element={<VerifyEmail />} />
-        <Route path="chat" element={<ChatPage />} />
-        <Route path="dashboard" element={<Dashboard />} />
+        <Route path="chat" element={<PrivateRoute><ChatPage /></PrivateRoute>} />
+        <Route path="dashboard" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
       </Route>
     </Routes>
   );

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -16,7 +16,7 @@ export const loginUser = async (data) => {
 //   return response.data;
 // };
 
-// export const verifyEmail = async (data) => {
-//   const response = await axiosInstance.post("/api/auth/verify-email", data);
-//   return response.data;
-// };
+export const verifyEmail = async (data) => {
+  const response = await axiosInstance.post("/api/auth/verify-email", data);
+  return response.data;
+};

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -2,13 +2,11 @@ import axiosInstance from "./axiosInstance";
 
 export const registerUser = async (data) => {
   const response = await axiosInstance.post("/api/auth/register", data);
-  console.log(response);
   return response.data;
 };
 
 export const loginUser = async (data) => {
   const response = await axiosInstance.post("/api/auth/login", data);
-  console.log(response);
   return response.data;
 };
 

--- a/src/api/axiosInstance.js
+++ b/src/api/axiosInstance.js
@@ -1,5 +1,4 @@
 import axios from "axios";
-
 const axiosInstance = axios.create({
   headers: {
     "Content-Type": "application/json",
@@ -24,6 +23,7 @@ axiosInstance.interceptors.response.use(
   (error) => {
     if (error.response?.status === 401) {
       localStorage.removeItem("token");
+      localStorage.removeItem("userId");
       window.location.href = "/login";
     }
     return Promise.reject(error);

--- a/src/api/axiosInstance.js
+++ b/src/api/axiosInstance.js
@@ -19,4 +19,15 @@ axiosInstance.interceptors.request.use(
   },
 );
 
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem("token");
+      window.location.href = "/login";
+    }
+    return Promise.reject(error);
+  },
+);
+
 export default axiosInstance;

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,8 +1,8 @@
 import "./Button.css";
 
-export default function Button({ children, onClick, type = "button" }) {
+export default function Button({ children, onClick, type = "button", ...props }) {
   return (
-    <button className="btn" type={type} onClick={onClick}>
+    <button className="btn" type={type} onClick={onClick} {...props}>
       {children}
     </button>
   );

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,8 +1,8 @@
 import "./Button.css";
 
-export default function Button({ children, onClick, type = "button", ...props }) {
+export default function Button({ children, onClick, disabled , type = "button", ...props }) {
   return (
-    <button className="btn" type={type} onClick={onClick} {...props}>
+    <button className="btn" type={type} onClick={onClick} disabled={disabled} {...props}>
       {children}
     </button>
   );

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -4,12 +4,7 @@ export default function Header() {
   const location = useLocation();
   const path = location.pathname;
 
-  const isActive = (route) => {
-    if (route === "/") {
-      return path === "/" || path === "/signup";
-    }
-    return path === route;
-  };
+  const isActive = (route) => path === route;
 
   return (
     <header className="flex gap-12 items-center px-20 py-6 border-b border-[#eee] bg-[#e9f6ff]">

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -1,0 +1,6 @@
+import { Navigate } from "react-router-dom";
+
+export default function PrivateRoute({ children }) {
+  const token = localStorage.getItem("token");
+  return token ? children : <Navigate to="/login" replace />;
+}

--- a/src/pages/Chat/ChatPage.js
+++ b/src/pages/Chat/ChatPage.js
@@ -6,6 +6,7 @@ import ChatArea from "./Components/ChatArea/ChatArea";
 import { useState, useEffect } from "react";
 import { Client } from "@stomp/stompjs";
 import MembersList from "./Components/MembersList/MembersList";
+import { getCurrentUserId } from "../../utils/auth";
 
 export default function ChatPage() {
   const [activeChannel, setActiveChannel] = useState(null);
@@ -18,7 +19,7 @@ export default function ChatPage() {
       try {
         const ticketRes = await fetch("/api/chat/ws-ticket", {
           method: "POST",
-          headers: { "X-User-Id": "1", "X-User-Role": "USER" }
+          headers: { "X-User-Id": String(getCurrentUserId()), "X-User-Role": "USER" }
         });
         if (!ticketRes.ok) {
           const errorText = await ticketRes.text();

--- a/src/pages/Chat/ChatPage.js
+++ b/src/pages/Chat/ChatPage.js
@@ -33,8 +33,10 @@ export default function ChatPage() {
           return;
         }
 
+        const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+        const wsHost = window.location.host;
         client = new Client({
-          brokerURL: `ws://localhost:8084/api/chat/connect?ticket=${ticket}`,
+          brokerURL: `${wsProtocol}//${wsHost}/api/chat/connect?ticket=${ticket}`,
           onConnect: () => {
             console.log("Connected to STOMP!");
             setStompClient(client);

--- a/src/pages/Chat/ChatPage.js
+++ b/src/pages/Chat/ChatPage.js
@@ -7,25 +7,76 @@ import { useState, useEffect } from "react";
 import { Client } from "@stomp/stompjs";
 import MembersList from "./Components/MembersList/MembersList";
 import { getCurrentUserId } from "../../utils/auth";
+import { getCurrentUser } from "../../api/user";
+import { useNavigate } from "react-router-dom"; // 🌟 Import useNavigate
 
 export default function ChatPage() {
+  const navigate = useNavigate(); // 🌟 Define navigate hook
   const [activeChannel, setActiveChannel] = useState(null);
   const [stompClient, setStompClient] = useState(null);
+  const [loadingUser, setLoadingUser] = useState(true);
 
   useEffect(() => {
-    let client; // 1. Local variable holds the reference
+    const initUser = async () => {
+      // 🌟 PROACTIVE CHECK 1: If there is no token right at the start, don't even try to fetch a profile
+      const token = localStorage.getItem("token");
+      if (!token) {
+        navigate("/login", { replace: true });
+        return;
+      }
+
+      try {
+        const user = await getCurrentUser();
+        if (user && user.id) {
+          localStorage.setItem("userId", String(user.id));
+        }
+      } catch (err) {
+        console.error("Failed to fetch current user profile:", err);
+        // If the user profile request fails (e.g. 401 token invalid/expired), throw them out
+        navigate("/login", { replace: true });
+      } finally {
+        setLoadingUser(false);
+      }
+    };
+    initUser();
+  }, [navigate]);
+
+  useEffect(() => {
+    if (loadingUser) return;
+
+    let client;
 
     const connectWebSocket = async () => {
       try {
-        const ticketRes = await fetch("/api/chat/ws-ticket", {
-          method: "POST",
-          headers: { "X-User-Id": String(getCurrentUserId()), "X-User-Role": "USER" }
-        });
-        if (!ticketRes.ok) {
-          const errorText = await ticketRes.text();
-          console.error("Failed to fetch websocket ticket. Server returned:", errorText);
+        // 🌟 PROACTIVE CHECK 2: Double check token existence right before starting the WebSocket ticket pipeline
+        if (!localStorage.getItem("token")) {
+          navigate("/login", { replace: true });
           return;
         }
+
+        const ticketRes = await fetch("/api/chat/ws-ticket", {
+          method: "POST",
+          headers: {
+            "X-User-Id": String(getCurrentUserId()),
+            "X-User-Role": "USER",
+          },
+        });
+
+        if (!ticketRes.ok) {
+          const errorText = await ticketRes.text();
+          console.error(
+            "Failed to fetch websocket ticket. Server returned:",
+            errorText,
+          );
+          // If the handshake fails because of an authentication error, clean up
+          if (ticketRes.status === 401 || ticketRes.status === 400) {
+            localStorage.removeItem("token");
+            localStorage.removeItem("userId");
+            navigate("/login", { replace: true });
+          }
+          return;
+        }
+
         const data = await ticketRes.json();
         const ticket = data.ticket;
         console.log("Fetched ticket:", ticket);
@@ -34,7 +85,8 @@ export default function ChatPage() {
           return;
         }
 
-        const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+        const wsProtocol =
+          window.location.protocol === "https:" ? "wss:" : "ws:";
         const wsHost = window.location.host;
         client = new Client({
           brokerURL: `${wsProtocol}//${wsHost}/api/chat/connect?ticket=${ticket}`,
@@ -42,12 +94,12 @@ export default function ChatPage() {
             console.log("Connected to STOMP!");
             setStompClient(client);
 
-            client.subscribe('/user/queue/errors', (msg) => {
+            client.subscribe("/user/queue/errors", (msg) => {
               console.error("STOMP Error:", JSON.parse(msg.body));
             });
           },
           onStompError: (frame) => {
-            console.error("Broker reported error: " + frame.headers['message']);
+            console.error("Broker reported error: " + frame.headers["message"]);
             console.error("Additional details: " + frame.body);
           },
         });
@@ -59,11 +111,28 @@ export default function ChatPage() {
 
     connectWebSocket();
 
-    // 2. Cleanup function looks at the local block scope variable 'client'
     return () => {
       if (client) client.deactivate();
     };
-  }, []); // 3. The array safely stays empty!
+  }, [loadingUser, navigate]);
+
+  if (loadingUser) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          height: "100vh",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "'Inter', sans-serif",
+          fontSize: "16px",
+          color: "#64748b",
+        }}
+      >
+        Loading chat workspace...
+      </div>
+    );
+  }
 
   return (
     <div className="chatPage">

--- a/src/pages/Chat/Components/ChatArea/ChatHeader/ChatHeader.js
+++ b/src/pages/Chat/Components/ChatArea/ChatHeader/ChatHeader.js
@@ -4,6 +4,7 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import SearchOutlinedIcon from "@mui/icons-material/SearchOutlined";
 import NumbersIcon from "@mui/icons-material/Numbers";
 import { useState } from "react";
+import { getCurrentUserId } from "../../../../../utils/auth";
 export default function ChatHeader({ activeChannel }) {
   let channelNameForDisplay = "Loading...";
   if (activeChannel !== null) {
@@ -33,7 +34,7 @@ export default function ChatHeader({ activeChannel }) {
           method: "GET",
           headers: {
             "Content-Type": "application/json",
-            "X-User-Id": "1",
+            "X-User-Id": String(getCurrentUserId()),
             "X-User-Role": "USER",
           },
         });
@@ -64,7 +65,7 @@ export default function ChatHeader({ activeChannel }) {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
-              "X-User-Id": "1",
+              "X-User-Id": String(getCurrentUserId()),
               "X-User-Role": "USER",
             },
           },

--- a/src/pages/Chat/Components/ChatArea/ChatHeader/ChatHeader.js
+++ b/src/pages/Chat/Components/ChatArea/ChatHeader/ChatHeader.js
@@ -93,7 +93,7 @@ export default function ChatHeader({ activeChannel }) {
         </h3>
         <span className="margin">|</span>
         <span className="channel-description">
-          Company-wide announcements and office chatter
+          {channelDetails?.description || ""}
         </span>
       </div>
 

--- a/src/pages/Chat/Components/ChatArea/MessageInput/MessageInput.js
+++ b/src/pages/Chat/Components/ChatArea/MessageInput/MessageInput.js
@@ -17,7 +17,8 @@ export default function MessageInput({ activeChannel, stompClient }) {
   if (!message.trim() || !activeChannel?.id) return;
   
   if (stompClient && stompClient.connected) {
-    // Fix: Wrap custom fields inside a JSON-stringified body property
+    const storedUserId = localStorage.getItem("userId");
+
     stompClient.publish({
       destination: "/app/chat/send",
       body: JSON.stringify({
@@ -27,6 +28,7 @@ export default function MessageInput({ activeChannel, stompClient }) {
         replyToId: null,
         mentions: [],
         clientMessageId: crypto.randomUUID(),
+        userId: storedUserId ? Number(storedUserId) : null,
       })
     });
     setMessage("");

--- a/src/pages/Chat/Components/ChatArea/MessagesList/Message/Message.js
+++ b/src/pages/Chat/Components/ChatArea/MessagesList/Message/Message.js
@@ -6,6 +6,7 @@ import PersonAddAltOutlinedIcon from "@mui/icons-material/PersonAddAltOutlined";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
 import { useState, useEffect } from "react";
+import { getCurrentUserId } from "../../../../../../utils/auth";
 
 export default function Message({ message, stompClient }) {
   // --- Message State ---
@@ -32,7 +33,7 @@ export default function Message({ message, stompClient }) {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
-          "X-User-Id": "1", // Hardcoded user ID
+          "X-User-Id": String(getCurrentUserId()),
           "X-User-Role": "USER",
         },
         body: JSON.stringify({ content: editedText }),
@@ -61,7 +62,7 @@ export default function Message({ message, stompClient }) {
       const response = await fetch(`/api/chat/messages/${message.id}`, {
         method: "DELETE",
         headers: {
-          "X-User-Id": "1",
+          "X-User-Id": String(getCurrentUserId()),
           "X-User-Role": "USER",
         },
       });
@@ -95,7 +96,7 @@ export default function Message({ message, stompClient }) {
 
   if (!currentContent || currentContent.trim() === "") return null;
   // Show actions only for current user's messages
-  const isMyMessage = message.senderId === 1;
+  const isMyMessage = message.senderId === getCurrentUserId();
 
   return (
     <div className="message">

--- a/src/pages/Chat/Components/ChatArea/MessagesList/MessagesList.js
+++ b/src/pages/Chat/Components/ChatArea/MessagesList/MessagesList.js
@@ -25,7 +25,7 @@ export default function MessagesList({ activeChannel, stompClient }) {
         );
         if (response.ok) {
           const data = await response.json();
-          const orderedMessages = data.content ? data.content.reverse() : [];
+          const orderedMessages = data.content ? [...data.content].reverse() : [];
           setMessages(orderedMessages);
         } else {
           console.error("Failed to fetch messages from server");

--- a/src/pages/Chat/Components/ChatArea/MessagesList/MessagesList.js
+++ b/src/pages/Chat/Components/ChatArea/MessagesList/MessagesList.js
@@ -1,6 +1,7 @@
 import "./MessagesList.css";
 import Message from "./Message/Message";
 import { useState, useEffect } from "react";
+import { getCurrentUserId } from "../../../../../utils/auth";
 
 export default function MessagesList({ activeChannel, stompClient }) {
   const [messages, setMessages] = useState([]);
@@ -18,7 +19,7 @@ export default function MessagesList({ activeChannel, stompClient }) {
             method: "GET",
             headers: {
               "Content-Type": "application/json",
-              "X-User-Id": "1", // Hardcoded user ID for testing
+              "X-User-Id": String(getCurrentUserId()),
               "X-User-Role": "USER",
             },
           },

--- a/src/pages/Chat/Components/SettingsModal/SettingsModal.js
+++ b/src/pages/Chat/Components/SettingsModal/SettingsModal.js
@@ -43,7 +43,7 @@ export default function SettingsModal({
     setSuccess("");
     try {
       const result = await updatePassword({ oldPassword, newPassword });
-      if (result.status === "succeeded") {
+      if (result.status === "success") {
         setSuccess("Password updated successfully");
         setOldPassword("");
         setNewPassword("");
@@ -63,7 +63,7 @@ export default function SettingsModal({
 
     try {
       const result = await uploadPhoto(file);
-      if (result.status === "succeeded") {
+      if (result.status === "success") {
         setSuccess("Profile picture updated successfully!");
         if (onUpdate) onUpdate();
       }

--- a/src/pages/Chat/Components/SettingsModal/SettingsModal.js
+++ b/src/pages/Chat/Components/SettingsModal/SettingsModal.js
@@ -57,7 +57,7 @@ export default function SettingsModal({
     const file = event.target.files[0];
     if (!file) return;
 
-    // preview uploaded photo
+    const previousPreview = photoPreview;
     const previewUrl = URL.createObjectURL(file);
     setPhotoPreview(previewUrl);
 
@@ -69,7 +69,7 @@ export default function SettingsModal({
       }
     } catch (err) {
       setError(err.response?.data?.Error || "Failed to upload photo");
-      setPhotoPreview(null);
+      setPhotoPreview(previousPreview);
     }
   };
 

--- a/src/pages/Chat/Components/SettingsModal/SettingsModal.js
+++ b/src/pages/Chat/Components/SettingsModal/SettingsModal.js
@@ -43,7 +43,7 @@ export default function SettingsModal({
     setSuccess("");
     try {
       const result = await updatePassword({ oldPassword, newPassword });
-      if (result.status === "success") {
+      if (result.status === "succeeded" || result.data?.message === "succeeded") {
         setSuccess("Password updated successfully");
         setOldPassword("");
         setNewPassword("");
@@ -63,7 +63,7 @@ export default function SettingsModal({
 
     try {
       const result = await uploadPhoto(file);
-      if (result.status === "success") {
+      if (result.status === "succeeded" || result.data?.message === "succeeded") {
         setSuccess("Profile picture updated successfully!");
         if (onUpdate) onUpdate();
       }

--- a/src/pages/Chat/Components/Sidebar/Sidebar.js
+++ b/src/pages/Chat/Components/Sidebar/Sidebar.js
@@ -9,6 +9,7 @@ import { useState, useEffect } from "react";
 import { getCurrentUser } from "../../../../api/user";
 import SettingsModal from "../SettingsModal/SettingsModal";
 import { getUserPhoto } from "../../../../api/user";
+import { getCurrentUserId } from "../../../../utils/auth";
 
 export default function Sidebar({ activeChannel, setActiveChannel }) {
   // Channels state
@@ -35,7 +36,7 @@ export default function Sidebar({ activeChannel, setActiveChannel }) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-User-Id": "1",
+          "X-User-Id": String(getCurrentUserId()),
           "X-User-Role": "USER",
         },
         body: JSON.stringify({
@@ -74,7 +75,7 @@ export default function Sidebar({ activeChannel, setActiveChannel }) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-User-Id": "1", // Hardcoded user ID, update dynamically later
+          "X-User-Id": String(getCurrentUserId()), // Hardcoded user ID, update dynamically later
           "X-User-Role": "USER",
         },
         body: JSON.stringify({
@@ -104,7 +105,7 @@ export default function Sidebar({ activeChannel, setActiveChannel }) {
             method: "GET",
             headers: {
               "Content-Type": "application/json",
-              "X-User-Id": "1",
+              "X-User-Id": String(getCurrentUserId()),
               "X-User-Role": "USER",
             },
           },
@@ -142,7 +143,7 @@ export default function Sidebar({ activeChannel, setActiveChannel }) {
           method: "GET",
           headers: {
             "Content-Type": "application/json",
-            "X-User-Id": "1",
+            "X-User-Id": String(getCurrentUserId()),
             "X-User-Role": "USER",
           },
         });

--- a/src/pages/Chat/Components/Sidebar/Sidebar.js
+++ b/src/pages/Chat/Components/Sidebar/Sidebar.js
@@ -159,7 +159,7 @@ export default function Sidebar({ activeChannel, setActiveChannel }) {
 
     fetchChannels();
     fetchDMs();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const fetchUser = async () => {
@@ -188,7 +188,7 @@ export default function Sidebar({ activeChannel, setActiveChannel }) {
   //   avatar: "/user.jpg",
   //   status: "Set Status",
   // };
-
+  console.log("Current User ID extracted from token:", getCurrentUserId());
   return (
     <div className="sidebar-container">
       <div className="sidebar">
@@ -255,7 +255,8 @@ export default function Sidebar({ activeChannel, setActiveChannel }) {
             <div className="direct-messages-list">
               {dms.map((dm) => {
                 // Find the other user's ID to use as DM name
-                const otherUserId = dm.members?.find((m) => m !== 1);
+                const currentId = getCurrentUserId();
+                const otherUserId = dm.members?.find((m) => m !== currentId);
                 const dmDisplayName = dm.name
                   ? dm.name
                   : `User ${otherUserId || "X"}`;

--- a/src/pages/Chat/Components/Sidebar/Sidebar.js
+++ b/src/pages/Chat/Components/Sidebar/Sidebar.js
@@ -158,7 +158,8 @@ export default function Sidebar({ activeChannel, setActiveChannel }) {
 
     fetchChannels();
     fetchDMs();
-  }, [activeChannel, setActiveChannel]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const fetchUser = async () => {
     try {

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -16,7 +16,7 @@ export default function Login() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-
+    if(loading) return
     setLoading(true);
     setError("");
 
@@ -26,8 +26,9 @@ export default function Login() {
         password: password,
       });
 
-      if (!response.token) {
+      if (!response.token || !response) {
         setError("Invalid email or password.");
+        setLoading(false);
         return;
       }
       localStorage.setItem("token", response.token);

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -26,10 +26,13 @@ export default function Login() {
         password: password,
       });
 
+      if (!response.token) {
+        setError("Invalid email or password.");
+        return;
+      }
       localStorage.setItem("token", response.token);
       navigate("/chat");
     } catch (err) {
-      console.log("Response : ", err.response);
       if (err.response) {
         const backendData = err.response.data;
 

--- a/src/pages/Signup/Signup.js
+++ b/src/pages/Signup/Signup.js
@@ -31,6 +31,10 @@ export default function Signup() {
         phoneNumber: phoneNumber,
       });
 
+      if (!response.token) {
+        setError(response.errorMessage || "Registration failed. Please try again.");
+        return;
+      }
       localStorage.setItem("token", response.token);
       navigate("/dashboard");
     } catch (err) {

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -20,6 +20,7 @@ module.exports = function (app) {
     createProxyMiddleware({
       target: "http://localhost:8084",
       changeOrigin: true,
+      ws: true,
     }),
   );
 };

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,17 +1,24 @@
 /**
  * Decodes the JWT stored in localStorage and returns the numeric user ID.
  * Returns null if no token exists or the token is malformed.
- */
-export function getCurrentUserId() {
+ */ export function getCurrentUserId() {
   const token = localStorage.getItem("token");
   if (!token) return null;
 
   try {
-    const payload = JSON.parse(atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")));
+    const payload = JSON.parse(
+      atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")),
+    );
     // user-service embeds the numeric id in the "sub" claim as a string
-    const id = parseInt(payload.sub, 10);
-    return isNaN(id) ? null : id;
+    let idValue = payload.userId || payload.id || payload.sub;
+    const id = parseInt(idValue, 10);
+    if(isNaN(id)){
+      const cachedId = localStorage.getItem("userId");
+      return cachedId? parseInt(cachedId, 10) : null ;
+    }
+    return id;
   } catch {
-    return null;
+    const cachedId = localStorage.getItem("userId")
+    return cachedId ? parseInt(cachedId, 10) : null 
   }
 }

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,17 @@
+/**
+ * Decodes the JWT stored in localStorage and returns the numeric user ID.
+ * Returns null if no token exists or the token is malformed.
+ */
+export function getCurrentUserId() {
+  const token = localStorage.getItem("token");
+  if (!token) return null;
+
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")));
+    // user-service embeds the numeric id in the "sub" claim as a string
+    const id = parseInt(payload.sub, 10);
+    return isNaN(id) ? null : id;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Bug fixes across the frontend following the user-service integration and real-time chat (PR #2). All changes are backward-compatible — no API contracts or data structures were altered.

### Auth & security
- **Button `disabled` prop not forwarded** — Login/Signup submit buttons could be clicked multiple times while a request was in-flight, firing duplicate auth requests
- **JWT token logged to console** — `registerUser` and `loginUser` both called `console.log(response)`, exposing the token and email in the browser console
- **Null token stored as string** — When the backend returned `token: null` on error, both Login and Signup stored the literal string `"null"` in `localStorage`, breaking all subsequent requests
- **No 401 response interceptor** — Expired tokens left the user stuck with silent failures; now clears `localStorage` and redirects to `/login`
- **No route guards** — `/chat` and `/dashboard` were accessible without a token; added `PrivateRoute` component

### Chat
- **Sidebar re-fetched channels/DMs on every channel click** — `useEffect` dependency array included `activeChannel`, triggering a full re-fetch on every selection
- **WebSocket connected directly to `ws://localhost:8084`** — bypassed the CRA dev proxy and hardcoded the backend port; now derives the URL from `window.location.host` and routes through the proxy (`ws: true` added to `setupProxy.js`)
- **`X-User-Id: "1"` hardcoded in all 6 chat components** — added `src/utils/auth.js` with `getCurrentUserId()` that decodes the JWT `sub` claim; replaced every hardcoded `"1"` including the `isMyMessage` comparison in `Message.js`
- **`MessagesList.reverse()` mutated the API response array** — changed to `[...data.content].reverse()`
- **ChatHeader description hardcoded** — "Company-wide announcements and office chatter" shown for every channel; now renders `channelDetails?.description`

### Settings
- **SettingsModal status check `"succeeded"` vs `"success"`** — success branch was dead code; confirmation message and form-clear never ran
- **Failed photo upload cleared existing avatar** — `setPhotoPreview(null)` on error wiped the user's current photo; now restores the previous preview

### Pages & routing
- **`VerifyEmail` imported a commented-out function** — `verifyEmail` was commented out in `auth.js`, causing a `TypeError` at runtime; uncommented and added the missing `/verify-email` route to `App.js`
- **Home nav link active on Signup page** — `isActive("/")` incorrectly returned `true` for `/signup`; simplified to a direct equality check

## Test plan
- [x] Register a new user → token stored, redirect to dashboard
- [x] Login with wrong password → error shown, no token stored, button not double-submittable
- [x] Login with correct credentials → redirect to `/chat`, WebSocket connects
- [x] Navigate to `/chat` without a token → redirected to `/login`
- [x] Open `/verify-email` directly → page renders without crashing
- [x] Switch channels → network tab shows channels/DMs fetched only once on mount
- [x] Edit/delete a message as the correct user → actions visible only on own messages
- [x] Upload a profile photo that fails → existing avatar remains visible
- [x] Change password successfully → success message appears and fields clear
- [x] Let token expire → next request clears storage and redirects to `/login`